### PR TITLE
An alternative fix to crash after code sets selectedAnnotation = NULL.

### DIFF
--- a/Annotation.c
+++ b/Annotation.c
@@ -354,10 +354,7 @@ int Annotation_select(XButtonEvent *event, AnnotationInfo *ai)
   touchedAnnotation = findTouchedAnnotation(event,ai);
   if (touchedAnnotation == NULL || ((event->button == Button1) &&
       touchedAnnotation == ai->selectedAnnotation) ) {
-    /* This is commented out based on a bug report that StripTool
-       was segfaulting on Ubuntu Xenial when left mouse clicked unless
-       this was commented out. */
-    /*ai->selectedAnnotation  = NULL;*/
+    ai->selectedAnnotation  = NULL;
     return 0;
   } else {
     ai->selectedAnnotation  = touchedAnnotation;
@@ -811,6 +808,8 @@ void Annotation_move(XButtonEvent *event, AnnotationInfo *ai)
   Dimension    height;
   
   annotation = ai->selectedAnnotation;
+  if (!annotation)
+  	return;
   rec.x = (short)annotation->box.rasterX;
   rec.y = (short)annotation->box.rasterY;
   rec.width = (unsigned short)annotation->box.width;

--- a/Annotation.c
+++ b/Annotation.c
@@ -842,6 +842,8 @@ void Annotation_transformRasterValues(AnnotationInfo *ai, int width, int height)
   Annotation           *annotation;
 
   annotation = ai->selectedAnnotation;
+  if (!annotation)
+  	return;
   annotation->box.x = 0;
   annotation->box.y = 0;
 


### PR DESCRIPTION
Both Annotation_select() and Annotation_move() are conditionally called in the same
block of widget code in Scan.c that handles Button2.
If something about the Ubuntu windowing system causes Annotation_move() to be
called after setting that ptr NULL, Annotation_move() needs to guard against it.